### PR TITLE
Add support for getting components using the JUCE component ID

### DIFF
--- a/documentation/integration-guide.md
+++ b/documentation/integration-guide.md
@@ -93,10 +93,17 @@ private:
 }
 ```
 
-If you wish to reference a `Component` by ID, you can do so as follows:
+If you wish to reference a `Component` by ID, you can set the component ID on the component:
 
 ```C++
-myComponent.getProperties ().set ("test-id", "my-component-id");
+myComponent.setComponentID ("my-component-id");
+```
+
+If you happen to be using the component ID for something else, you can set the test ID as follows:
+```C++
+#include <focusrite/e2e/ComponentSearch.h>
+// ...
+focusrite::e2e::ComponentSearch::setTestId ("my-component-id");
 ```
 
 If you wish to install a custom request handler in addition to the default one,
@@ -140,15 +147,16 @@ commands and query its state. You can use it with any testing/assertion library
 (e.g. Jest, Mocha). The examples below are written in TypeScript using Jest.
 
 1. Install Node (you can use a Node installer, a system package manager, or a Node version manager)
-1. Initialise an npm package at the root of your repository using
+2. Initialise an npm package at the root of your repository using
    ```
    npm init
    ```
-1. Install the library using npm
+3. Install the library using npm
     ```
     npm install @focusritegroup/juce-end-to-end
     ```
-1. In your test setup, before each test, create an `AppConnection` (passing it 
+4. Install a test framework (e.g. Jest)
+5. In your test setup, before each test, create an `AppConnection` (passing it 
 the path to your built application) and wait for it to launch. You can pass the
 app extra arguments or set environment variables if you need to put it into 
 special state.
@@ -166,7 +174,7 @@ special state.
     }
     ```
 
-1. After each test, quit the app and wait for it to shut down:
+6. After each test, quit the app and wait for it to shut down:
 
     ```TypeScript
     afterEach(async () => {
@@ -174,7 +182,7 @@ special state.
     });
     ```
 
-1. During each test, you can send the application commands to query the state
+7. During each test, you can send the application commands to query the state
 of the user interface. Here is a simple example:
 
     ```TypeScript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@focusrite-novation/juce-end-to-end",
+  "name": "@focusritegroup/juce-end-to-end",
   "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,

--- a/source/cpp/CMakeLists.txt
+++ b/source/cpp/CMakeLists.txt
@@ -26,6 +26,11 @@ target_include_directories (focusrite-e2e PUBLIC include)
 set (JUCE_MODULES juce_core juce_events)
 
 foreach (JUCE_MODULE ${JUCE_MODULES})
+ 
+  if (NOT TARGET ${JUCE_MODULE})
+    message(FATAL_ERROR "Missing JUCE module: ${JUCE_MODULE}, enable FOCUSRITE_E2E_FETCH_JUCE to fetch JUCE")
+  endif()
+
   get_target_property (MODULE_INCLUDES ${JUCE_MODULE}
                        INTERFACE_INCLUDE_DIRECTORIES)
   target_include_directories (focusrite-e2e PUBLIC ${MODULE_INCLUDES})

--- a/source/cpp/CMakeLists.txt
+++ b/source/cpp/CMakeLists.txt
@@ -43,8 +43,10 @@ source_group (TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${FOCUSRITE_E2E_SOURCES})
 
 if (FOCUSRITE_E2E_MAKE_TESTS)
 
-  add_executable (focusrite-e2e-tests ./tests/main.cpp ./tests/TestCommand.cpp
-                                      ./tests/TestResponse.cpp)
+  add_executable (
+    focusrite-e2e-tests
+    ./tests/main.cpp ./tests/TestCommand.cpp ./tests/TestComponentSearch.cpp
+    ./tests/TestResponse.cpp)
 
   target_link_libraries (focusrite-e2e-tests PRIVATE focusrite-e2e)
 

--- a/source/cpp/include/focusrite/e2e/ComponentSearch.h
+++ b/source/cpp/include/focusrite/e2e/ComponentSearch.h
@@ -7,9 +7,6 @@ namespace focusrite::e2e
 class ComponentSearch
 {
 public:
-    static constexpr char testId [] = "test-id";
-    static constexpr char windowId [] = "window-id";
-
     static juce::Component * findWithId (const juce::String & componentId, int skip = 0);
     static juce::TopLevelWindow * findWindowWithId (const juce::String & windowId = {});
 
@@ -17,6 +14,7 @@ public:
                                      const juce::String & matchingId);
 
     static void setTestId (juce::Component & component, const juce::String & id);
+    static void setWindowId (juce::TopLevelWindow & window, const juce::String & id);
 };
 
 }

--- a/source/cpp/source/DefaultCommandHandler.cpp
+++ b/source/cpp/source/DefaultCommandHandler.cpp
@@ -9,6 +9,47 @@
 
 namespace focusrite::e2e
 {
+enum class CommandArgument
+{
+    componentId,
+    focusComponent,
+    keyCode,
+    modifiers,
+    numClicks,
+    rootId,
+    skip,
+    title,
+    windowId,
+};
+
+juce::StringRef toString (CommandArgument argument)
+{
+    switch (argument)
+    {
+        case CommandArgument::componentId:
+            return "component-id";
+        case CommandArgument::focusComponent:
+            return "focus-component";
+        case CommandArgument::keyCode:
+            return "key-code";
+        case CommandArgument::modifiers:
+            return "modifiers";
+        case CommandArgument::numClicks:
+            return "num-clicks";
+        case CommandArgument::rootId:
+            return "root-id";
+        case CommandArgument::skip:
+            return "skip";
+        case CommandArgument::title:
+            return "title";
+        case CommandArgument::windowId:
+            return "window-id";
+    }
+
+    jassertfalse;
+    return {};
+}
+
 void clickButton (juce::Button & button)
 {
     if (button.onClick != nullptr)
@@ -77,7 +118,9 @@ bool clickClickableComponent (juce::Component & component, const Command & comma
     if (auto * clickable = dynamic_cast<ClickableComponent *> (&component))
     {
         clickClickableComponent (
-            *clickable, juce::jlimit (1, 2, command.getArgument ("num-clicks").getIntValue ()));
+            *clickable,
+            juce::jlimit (
+                1, 2, command.getArgument (toString (CommandArgument::numClicks)).getIntValue ()));
         return true;
     }
 
@@ -86,11 +129,11 @@ bool clickClickableComponent (juce::Component & component, const Command & comma
 
 Response clickComponent (const Command & command)
 {
-    const auto componentId = command.getArgument ("component-id");
+    const auto componentId = command.getArgument (toString (CommandArgument::componentId));
     if (componentId == juce::String ())
         return Response::fail ("Missing component-id");
 
-    auto skip = command.getArgument ("skip").getIntValue ();
+    auto skip = command.getArgument (toString (CommandArgument::skip)).getIntValue ();
 
     auto component = ComponentSearch::findWithId (componentId, skip);
     if (component == nullptr)
@@ -130,13 +173,13 @@ Response keyPressOnWindow (const juce::String & windowId, const juce::KeyPress &
 
 Response keyPress (const Command & command)
 {
-    auto keyCode = command.getArgument ("key-code");
+    auto keyCode = command.getArgument (toString (CommandArgument::keyCode));
     if (keyCode.isEmpty ())
         return Response::fail ("Missing key-code argument");
 
-    auto modifiers = command.getArgument ("modifiers");
-    auto componentId = command.getArgument ("focus-component");
-    auto windowId = command.getArgument ("window-id");
+    auto modifiers = command.getArgument (toString (CommandArgument::modifiers));
+    auto componentId = command.getArgument (toString (CommandArgument::focusComponent));
+    auto windowId = command.getArgument (toString (CommandArgument::windowId));
 
     const auto keyPress = constructKeyPress (keyCode, modifiers);
 
@@ -148,7 +191,8 @@ Response keyPress (const Command & command)
 
 Response grabFocus (const Command & command)
 {
-    if (auto * window = ComponentSearch::findWindowWithId (command.getArgument ("window-id")))
+    if (auto * window = ComponentSearch::findWindowWithId (
+            command.getArgument (toString (CommandArgument::windowId))))
         window->grabKeyboardFocus ();
 
     return Response::ok ();
@@ -156,8 +200,8 @@ Response grabFocus (const Command & command)
 
 Response getScreenshot (const Command & command)
 {
-    const auto componentId = command.getArgument ("component-id");
-    const auto windowId = command.getArgument ("window-id");
+    const auto componentId = command.getArgument (toString (CommandArgument::componentId));
+    const auto windowId = command.getArgument (toString (CommandArgument::windowId));
 
     auto component = componentId.isEmpty () ? ComponentSearch::findWindowWithId (windowId)
                                             : ComponentSearch::findWithId (componentId);
@@ -174,7 +218,7 @@ Response getScreenshot (const Command & command)
 
 Response getComponentVisibility (const Command & command)
 {
-    const auto componentId = command.getArgument ("component-id");
+    const auto componentId = command.getArgument (toString (CommandArgument::componentId));
     if (componentId.isEmpty ())
         return Response::fail ("Missing component-id");
 
@@ -192,7 +236,7 @@ Response getComponentVisibility (const Command & command)
 
 Response getComponentEnablement (const Command & command)
 {
-    const auto componentId = command.getArgument ("component-id");
+    const auto componentId = command.getArgument (toString (CommandArgument::componentId));
     if (componentId.isEmpty ())
         return Response::fail ("Missing component-id");
 
@@ -210,7 +254,7 @@ Response getComponentEnablement (const Command & command)
 
 Response getComponentText (const Command & command)
 {
-    const auto componentId = command.getArgument ("component-id");
+    const auto componentId = command.getArgument (toString (CommandArgument::componentId));
     if (componentId.isEmpty ())
         return Response::fail ("Missing component-id");
 
@@ -241,13 +285,13 @@ Response getFocusComponent (const Command & command)
 
 Response countComponents (const Command & command)
 {
-    const auto componentId = command.getArgument ("component-id");
+    const auto componentId = command.getArgument (toString (CommandArgument::componentId));
 
     if (componentId.isEmpty ())
         return Response::fail ("Missing component-id");
 
-    const auto rootId = command.getArgument ("root-id");
-    const auto windowId = command.getArgument ("window-id");
+    const auto rootId = command.getArgument (toString (CommandArgument::rootId));
+    const auto windowId = command.getArgument (toString (CommandArgument::windowId));
 
     juce::Component * rootComponent = ComponentSearch::findWindowWithId (windowId);
 
@@ -276,7 +320,7 @@ Response invokeMenu (const Command & command)
     if (! application)
         return Response::fail ("Invalid application");
 
-    const auto menuTitle = command.getArgument ("title");
+    const auto menuTitle = command.getArgument (toString (CommandArgument::title));
     if (menuTitle.isEmpty ())
         return Response::fail ("Missing menu title");
 

--- a/source/cpp/source/DefaultCommandHandler.cpp
+++ b/source/cpp/source/DefaultCommandHandler.cpp
@@ -136,7 +136,7 @@ Response keyPress (const Command & command)
 
     auto modifiers = command.getArgument ("modifiers");
     auto componentId = command.getArgument ("focus-component");
-    auto windowId = command.getArgument (ComponentSearch::windowId);
+    auto windowId = command.getArgument ("window-id");
 
     const auto keyPress = constructKeyPress (keyCode, modifiers);
 
@@ -148,8 +148,7 @@ Response keyPress (const Command & command)
 
 Response grabFocus (const Command & command)
 {
-    if (auto * window =
-            ComponentSearch::findWindowWithId (command.getArgument (ComponentSearch::windowId)))
+    if (auto * window = ComponentSearch::findWindowWithId (command.getArgument ("window-id")))
         window->grabKeyboardFocus ();
 
     return Response::ok ();
@@ -158,7 +157,7 @@ Response grabFocus (const Command & command)
 Response getScreenshot (const Command & command)
 {
     const auto componentId = command.getArgument ("component-id");
-    const auto windowId = command.getArgument (ComponentSearch::windowId);
+    const auto windowId = command.getArgument ("window-id");
 
     auto component = componentId.isEmpty () ? ComponentSearch::findWindowWithId (windowId)
                                             : ComponentSearch::findWithId (componentId);
@@ -248,7 +247,7 @@ Response countComponents (const Command & command)
         return Response::fail ("Missing component-id");
 
     const auto rootId = command.getArgument ("root-id");
-    const auto windowId = command.getArgument (ComponentSearch::windowId);
+    const auto windowId = command.getArgument ("window-id");
 
     juce::Component * rootComponent = ComponentSearch::findWindowWithId (windowId);
 

--- a/source/cpp/tests/TestCommand.cpp
+++ b/source/cpp/tests/TestCommand.cpp
@@ -54,37 +54,40 @@ public:
 
     void convertsTypeFromJson ()
     {
+        const auto command = Command::fromJson (exampleJson);
         expectEquals (command.getType (), juce::String ("command-type"));
     }
 
     void convertsUuidFromJson ()
     {
+        const auto command = Command::fromJson (exampleJson);
         expect (command.getUuid () == juce::Uuid ("beb16073-dbcd-49aa-b7d1-9466582a1e0e"));
     }
 
     void convertsStringArgumentFromJson ()
     {
+        const auto command = Command::fromJson (exampleJson);
         expectEquals (command.getArgument ("string-type"), juce::String ("string argument"));
     }
 
     void convertsIntArgumentFromJson ()
     {
+        const auto command = Command::fromJson (exampleJson);
         expectEquals (command.getArgumentAs<int> ("int-type"), 45675);
     }
 
     void convertsBoolArgumentFromJson ()
     {
+        const auto command = Command::fromJson (exampleJson);
         expect (command.getArgumentAs<bool> ("bool-type"));
     }
 
     void convertsObjectArgumentFromJson ()
     {
+        const auto command = Command::fromJson (exampleJson);
         const auto var = command.getArgumentAsVar ("object-type");
         expectEquals (var.getProperty ("value", {}).toString (), juce::String ("object"));
     }
-
-private:
-    const Command command = Command::fromJson (exampleJson);
 };
 
 [[maybe_unused]] static CommandTests commandTests;

--- a/source/cpp/tests/TestComponentSearch.cpp
+++ b/source/cpp/tests/TestComponentSearch.cpp
@@ -68,6 +68,7 @@ public:
         componentA.addAndMakeVisible (componentB);
         componentA.addAndMakeVisible (componentC);
         window.addAndMakeVisible (componentA);
+        window.setVisible (true);
 
         expect (ComponentSearch::findWithId (componentAId) == &componentA);
         expect (ComponentSearch::findWithId (componentBId) == &componentB);
@@ -92,6 +93,7 @@ public:
         componentA.addAndMakeVisible (componentB);
         componentA.addAndMakeVisible (componentC);
         window.addAndMakeVisible (componentA);
+        window.setVisible (true);
 
         expect (ComponentSearch::findWithId (componentAId) == &componentA);
         expect (ComponentSearch::findWithId (componentBId) == &componentB);

--- a/source/cpp/tests/TestComponentSearch.cpp
+++ b/source/cpp/tests/TestComponentSearch.cpp
@@ -1,0 +1,104 @@
+#include <focusrite/e2e/ComponentSearch.h>
+#include <future>
+#include <juce_core/juce_core.h>
+
+namespace focusrite::e2e
+{
+template <typename Task>
+void runOnMessageQueue (Task task)
+{
+    auto messageManager = juce::MessageManager::getInstance ();
+    jassert (messageManager != nullptr);
+
+    juce::MessageManager::callAsync (
+        [task, messageManager]
+        {
+            task ();
+            messageManager->stopDispatchLoop ();
+        });
+
+    messageManager->runDispatchLoop ();
+}
+
+class ComponentSearchTests final : public juce::UnitTest
+{
+public:
+    ComponentSearchTests () noexcept
+        : juce::UnitTest ("ComponentSearch")
+    {
+    }
+
+    void runTest () override
+    {
+        struct Test
+        {
+            juce::String name;
+            std::function<void ()> entry;
+        };
+
+        auto tests = {
+            Test {"Finds component with component ID", [=] { findsComponentWithId (); }},
+            Test {"Finds component with test ID", [=] { findsComponentWithTestId (); }},
+        };
+
+        for (auto && test : tests)
+        {
+            beginTest (test.name);
+            runOnMessageQueue (test.entry);
+        }
+
+        juce::MessageManager::deleteInstance ();
+    }
+
+    void findsComponentWithId ()
+    {
+        constexpr auto componentAId = "component-a";
+        constexpr auto componentBId = "component-b";
+        constexpr auto componentCId = "component-c";
+
+        juce::TopLevelWindow window ("window", true);
+        juce::Component componentA;
+        juce::Component componentB;
+        juce::Component componentC;
+
+        componentA.setComponentID (componentAId);
+        componentB.setComponentID (componentBId);
+        componentC.setComponentID (componentCId);
+
+        componentA.addAndMakeVisible (componentB);
+        componentA.addAndMakeVisible (componentC);
+        window.addAndMakeVisible (componentA);
+
+        expect (ComponentSearch::findWithId (componentAId) == &componentA);
+        expect (ComponentSearch::findWithId (componentBId) == &componentB);
+        expect (ComponentSearch::findWithId (componentCId) == &componentC);
+    }
+
+    void findsComponentWithTestId ()
+    {
+        constexpr auto componentAId = "component-a";
+        constexpr auto componentBId = "component-b";
+        constexpr auto componentCId = "component-c";
+
+        juce::TopLevelWindow window ("window", true);
+        juce::Component componentA;
+        juce::Component componentB;
+        juce::Component componentC;
+
+        ComponentSearch::setTestId (componentA, componentAId);
+        ComponentSearch::setTestId (componentB, componentBId);
+        ComponentSearch::setTestId (componentC, componentCId);
+
+        componentA.addAndMakeVisible (componentB);
+        componentA.addAndMakeVisible (componentC);
+        window.addAndMakeVisible (componentA);
+
+        expect (ComponentSearch::findWithId (componentAId) == &componentA);
+        expect (ComponentSearch::findWithId (componentBId) == &componentB);
+        expect (ComponentSearch::findWithId (componentCId) == &componentC);
+    }
+};
+
+[[maybe_unused]] static ComponentSearchTests componentSearchTests;
+
+}


### PR DESCRIPTION
This adds support for referencing components using the JUCE ID, rather than via the component properties.

It will only set the property, but it will read the property or the component ID.