### PR TITLE
Add an earlier error if the app doesn't exist

### DIFF
--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -33,6 +33,14 @@ export interface EnvironmentVariables {
 
 const DEFAULT_TIMEOUT = 5000;
 
+const existsAsFile = (path: string) => {
+  try {
+    return fs.statSync(path).isFile();
+  } catch (error) {
+    return false;
+  }
+};
+
 export class AppConnection extends EventEmitter {
   appPath: string;
   process?: ChildProcess;
@@ -42,6 +50,12 @@ export class AppConnection extends EventEmitter {
 
   constructor(options: AppConnectionOptions) {
     super();
+
+    if (!existsAsFile(options.appPath)) {
+      throw new Error(
+        `The specified app path (${options.appPath}) doesn't exist`
+      );
+    }
 
     this.appPath = options.appPath;
     this.logDirectory = options.logDirectory;


### PR DESCRIPTION
If you don't specify the app path correctly, or if the app doesn't build, the error messages aren't particularly clear. This will throw an error if the app path doesn't exist