### PR TITLE
Add option to find nested Components using '/'

### DIFF
--- a/source/cpp/source/ComponentSearch.cpp
+++ b/source/cpp/source/ComponentSearch.cpp
@@ -136,7 +136,22 @@ int ComponentSearch::countChildComponents (const juce::Component & root,
 
 juce::Component * ComponentSearch::findWithId (const juce::String & componentId, int skip)
 {
-    return findComponent (createComponentMatcher (componentId), skip);
+    auto componentIds = juce::StringArray::fromTokens (componentId, "/", "");
+    if (componentIds.isEmpty ())
+        return nullptr;
+
+    auto * component = findComponent (createComponentMatcher (componentIds [0]), skip);
+    componentIds.remove (0);
+
+    for (auto && id : componentIds)
+    {
+        if (component == nullptr)
+            return nullptr;
+
+        component = findChildComponent (*component, createComponentMatcher (id), 0);
+    }
+
+    return component;
 }
 
 void ComponentSearch::setTestId (juce::Component & component, const juce::String & id)

--- a/source/cpp/tests/main.cpp
+++ b/source/cpp/tests/main.cpp
@@ -1,14 +1,84 @@
-#include <juce_core/juce_core.h>
+#include <future>
+#include <juce_events/juce_events.h>
 
-int main ()
+class Application : public juce::JUCEApplicationBase
 {
-    juce::UnitTestRunner runner;
-    runner.runAllTests ();
+public:
+    const juce::String getApplicationName () override // NOLINT
+    {
+        return {};
+    }
 
-    for (int resultIndex = 0; resultIndex < runner.getNumResults (); ++resultIndex)
-        if (auto result = runner.getResult (resultIndex))
-            if (result->failures > 0)
-                return 1;
+    const juce::String getApplicationVersion () override // NOLINT
+    {
+        return {};
+    }
 
-    return 0;
-}
+    bool moreThanOneInstanceAllowed () override
+    {
+        return false;
+    }
+
+    void initialise (const juce::String &) override
+    {
+        _testsResult = std::async (&Application::runTests);
+    }
+
+    void shutdown () override
+    {
+        juce::JUCEApplicationBase::setApplicationReturnValue (
+            _testsResult.get () == TestsResult::pass ? 0 : 1);
+    }
+
+    void anotherInstanceStarted (const juce::String &) override
+    {
+    }
+
+    void systemRequestedQuit () override
+    {
+    }
+
+    void suspended () override
+    {
+    }
+
+    void resumed () override
+    {
+    }
+
+    void unhandledException (const std::exception * exception,
+                             const juce::String & sourceFile,
+                             int lineNumber) override
+    {
+        juce::Logger::writeToLog ("Unhandled exception in " + sourceFile + "(" +
+                                  juce::String (lineNumber) + "): " + exception->what ());
+        juce::JUCEApplicationBase::setApplicationReturnValue (1);
+    }
+
+private:
+    enum class TestsResult
+    {
+        pass,
+        fail,
+    };
+
+    static TestsResult runTests ()
+    {
+        juce::UnitTestRunner runner;
+        runner.runAllTests ();
+
+        auto testsResults = TestsResult::pass;
+
+        for (int resultIndex = 0; resultIndex < runner.getNumResults (); ++resultIndex)
+            if (auto result = runner.getResult (resultIndex))
+                if (result->failures > 0)
+                    testsResults = TestsResult::fail;
+
+        juce::JUCEApplicationBase::quit ();
+        return testsResults;
+    }
+
+    std::future<TestsResult> _testsResult;
+};
+
+START_JUCE_APPLICATION (Application)


### PR DESCRIPTION
It will split the ID and iterate over the components. This allows deeply nested components to be referenced from tests.

Also... some of the tests weren't actually running as there wasn't a message thread. There is now an application in main (so that there is a message thread) that starts a separate thread to run the tests.