### PR TITLE
Add option to set text editor text

### DIFF
--- a/example/app/source/MainComponent.h
+++ b/example/app/source/MainComponent.h
@@ -20,6 +20,7 @@ public:
         addAndMakeVisible (_enableButton);
         addAndMakeVisible (_valueLabel);
         addAndMakeVisible (_slider);
+        addAndMakeVisible (_textEditor);
 
         _valueLabel.setJustificationType (juce::Justification::centred);
         _valueLabel.setColour (juce::Label::textColourId, juce::Colours::black);
@@ -31,8 +32,15 @@ public:
         _enableButton.setComponentID ("enable-button");
         _valueLabel.setComponentID ("value-label");
         _slider.setComponentID ("slider");
+        _textEditor.setComponentID ("text-editor");
 
-        _slider.onValueChange = [this] { setValue (_slider.getValue ()); };
+        _textEditor.onTextChange = [this]
+        {
+            const auto text = _textEditor.getText ();
+            setValue (text.getIntValue ());
+        };
+
+        _slider.onValueChange = [this] { setValue (static_cast<int> (_slider.getValue ())); };
     }
 
     void resized () override
@@ -50,9 +58,11 @@ public:
             spacer,
             juce::FlexItem (_decrementButton).withHeight (rowHeight),
             spacer,
-            juce::FlexItem (_valueLabel).withHeight (rowHeight),
-            spacer,
             juce::FlexItem (_slider).withHeight (rowHeight),
+            spacer,
+            juce::FlexItem (_textEditor).withHeight (rowHeight),
+            spacer,
+            juce::FlexItem (_valueLabel).withHeight (rowHeight),
         };
 
         static constexpr auto margin = 10;
@@ -89,6 +99,8 @@ private:
         auto willEnable = ! _incrementButton.isEnabled ();
         _incrementButton.setEnabled (willEnable);
         _decrementButton.setEnabled (willEnable);
+        _slider.setEnabled (willEnable);
+        _textEditor.setEnabled (willEnable);
         _enableButton.setButtonText (_incrementButton.isEnabled () ? "Disable" : "Enable");
     }
 
@@ -98,4 +110,5 @@ private:
     juce::TextButton _enableButton {"Disable"};
     juce::Label _valueLabel;
     juce::Slider _slider {juce::Slider::LinearHorizontal, juce::Slider::NoTextBox};
+    juce::TextEditor _textEditor;
 };

--- a/example/tests/counter-app.spec.ts
+++ b/example/tests/counter-app.spec.ts
@@ -14,26 +14,26 @@ describe('Count App tests', () => {
     await appConnection.quit();
   });
 
-  it('Starts at 0', async () => {
+  it('starts at 0', async () => {
     const value = await appConnection.getComponentText('value-label');
     expect(value).toEqual('0');
   });
 
-  it('Increments using the increment button', async () => {
+  it('increments using the increment button', async () => {
     await appConnection.clickComponent('increment-button');
 
     const value = await appConnection.getComponentText('value-label');
     expect(value).toEqual('1');
   });
 
-  it('Decrements using the decrement button', async () => {
+  it('decrements using the decrement button', async () => {
     await appConnection.clickComponent('decrement-button');
 
     const value = await appConnection.getComponentText('value-label');
     expect(value).toEqual('-1');
   });
 
-  it('Can be disabled', async () => {
+  it('can be disabled', async () => {
     expect(
       await appConnection.getComponentEnablement('increment-button')
     ).toBeTruthy();
@@ -51,10 +51,17 @@ describe('Count App tests', () => {
     ).toBeFalsy();
   });
 
-  it('Can set slider value', async () => {
+  it('sets value using the slider', async () => {
     const expectedValue = 6;
     await appConnection.setSliderValue('slider', expectedValue);
     const value = await appConnection.getSliderValue('slider');
     expect(value).toBe(expectedValue);
+  });
+
+  it('sets value using the text editor', async () => {
+    const expectedValue = 789;
+    await appConnection.setTextEditorText('text-editor', `${expectedValue}`);
+    const value = await appConnection.getComponentText('value-label');
+    expect(value).toBe(`${expectedValue}`);
   });
 });

--- a/source/cpp/source/DefaultCommandHandler.cpp
+++ b/source/cpp/source/DefaultCommandHandler.cpp
@@ -405,6 +405,28 @@ Response setSliderValue (const Command & command)
     return Response::fail (error);
 }
 
+Response setTextEditorText (const Command & command)
+{
+    const auto componentId = command.getArgument (toString (CommandArgument::componentId));
+    if (componentId.isEmpty ())
+        return Response::fail ("Missing component-id");
+
+    const auto text = command.getArgument (toString (CommandArgument::value));
+
+    if (auto * component = ComponentSearch::findWithId (componentId))
+    {
+        if (auto * textEditor = dynamic_cast<juce::TextEditor *> (component))
+        {
+            textEditor->setText (text, juce::sendNotificationSync);
+            return Response::ok ();
+        }
+
+        return Response::fail (componentId + " is not a juce::TextEditor");
+    }
+
+    return Response::fail (componentId + " not found");
+}
+
 std::optional<Response> DefaultCommandHandler::process (const Command & command)
 {
     static const std::map<juce::String, std::function<Response (const Command &)>> commandHandlers =
@@ -424,6 +446,10 @@ std::optional<Response> DefaultCommandHandler::process (const Command & command)
             {"invoke-menu", [&] (auto && command) { return invokeMenu (command); }},
             {"get-slider-value", [&] (auto && command) { return getSliderValue (command); }},
             {"set-slider-value", [&] (auto && command) { return setSliderValue (command); }},
+            {
+                "set-text-editor-text",
+                [&] (auto && command) { return setTextEditorText (command); },
+            },
         };
 
     auto it = commandHandlers.find (command.getType ());

--- a/source/cpp/source/DefaultCommandHandler.cpp
+++ b/source/cpp/source/DefaultCommandHandler.cpp
@@ -417,7 +417,8 @@ Response setTextEditorText (const Command & command)
     {
         if (auto * textEditor = dynamic_cast<juce::TextEditor *> (component))
         {
-            textEditor->setText (text, juce::sendNotificationSync);
+            static constexpr auto sendTextChangeMessage = true;
+            textEditor->setText (text, sendTextChangeMessage);
             return Response::ok ();
         }
 

--- a/source/ts/app-connection.ts
+++ b/source/ts/app-connection.ts
@@ -262,6 +262,16 @@ export class AppConnection extends EventEmitter {
     return response.value;
   }
 
+  async setTextEditorText(componentId: string, value: string): Promise<void> {
+    await this.sendCommand({
+      type: 'set-text-editor-text',
+      args: {
+        'component-id': componentId,
+        value,
+      },
+    });
+  }
+
   async invokeMenu(menu: string): Promise<void> {
     await this.sendCommand({
       type: 'invoke-menu',


### PR DESCRIPTION
Adds a command that can be used to set the text in a `juce::TextEditor`