### PR TITLE
Replace contains function with custom range check

### DIFF
--- a/source/cpp/source/DefaultCommandHandler.cpp
+++ b/source/cpp/source/DefaultCommandHandler.cpp
@@ -392,8 +392,7 @@ Response setSliderValue (const Command & command)
         const auto value =
             command.getArgument (toString (CommandArgument::value)).getDoubleValue ();
 
-        const auto sliderRange = slider->getRange ();
-        if (! sliderRange.contains (value))
+        if (value > slider->getMaximum () || value < slider->getMinimum ())
             return Response::fail ("Slider value out of range: " + juce::String (value));
 
         slider->setValue (value, juce::sendNotificationSync);


### PR DESCRIPTION
**Is this pull request to fix a bug?**
There is a bug when setting a slider value to the maximum value in which the E2E test default command handler reports the maximum value being out of range. This is because the range check currently uses the `.contains()` method which checks if the value is within the range inclusively at the minimum and exclusively at the maximum. 

To fix this I've replaced the contains call with a range check that includes the maximum value.


By submitting a pull request to this repository you are agreeing to assign the copyright on your submitted code to Focusrite Audio Engineering Ltd. Please check the box below to show you accept these terms. 

- [x] __I agree to assign copyright of any code accepted via this pull request process to Focusrite Audio engineering Ltd.__
