### PR TITLE
Upgrade Xcode version from 12.5.0 to 14.0.0 and to juce 7.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 aliases:
   - &macos-env
     macos:
-      xcode: 12.5.0
+      xcode: 13.4.1
       
   - &windows-env
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 aliases:
   - &macos-env
     macos:
-      xcode: 13.4.1
+      xcode: 14.0.0
       
   - &windows-env
     executor:

--- a/cmake/fetch-juce.cmake
+++ b/cmake/fetch-juce.cmake
@@ -1,6 +1,5 @@
 include (FetchContent)
 fetchcontent_declare (juce GIT_REPOSITORY https://github.com/juce-framework/JUCE
-                      GIT_TAG 6.1.2 GIT_SUBMODULES "")
+                      GIT_TAG 7.0.2 GIT_SUBMODULES "")
 
 fetchcontent_makeavailable (juce)
-


### PR DESCRIPTION
**Describe what your code does**

Upgrades the version of Xcode from 12.5.0 to version 14.0.0 and JUCE to 7.0.2

**Is this pull request to fix a bug?**

Currently the CI pipeline fails as 12.5.0 is no longer supported on circle CI, this PR upgrades Xcode and JUCE so that we can continue to build the E2E test framework on CI


By submitting a pull request to this repository you are agreeing to assign the copyright on your submitted code to Focusrite Audio Engineering Ltd. Please check the box below to show you accept these terms. 

- [x] __I agree to assign copyright of any code accepted via this pull request process to Focusrite Audio engineering Ltd.__
